### PR TITLE
Add support for "SLS invoke local"

### DIFF
--- a/src/lib/setEnvVariables.js
+++ b/src/lib/setEnvVariables.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * Set Serverless environment variables for local invocations
+ *
+ * @param {Serverless} serverless - Serverless Instance
+ * @param {Map<String>} environment - Resolved environment
+ */
+function setEnvVariables(serverless, environment) {
+	const functions = _.get(serverless, "service.functions", {});
+
+	// Set the function environment for all functions that define one
+	_.each(_.keys(functions), funcName => {
+		const funcEnv = functions[funcName].environment;
+
+		if (funcEnv) {
+			_.assign(funcEnv, _.reduce(funcEnv, (acc, value, key) => {
+				acc[key] = environment[key];
+			}, {}));
+		}
+	});
+
+	// Set the global environment
+	_.assign(serverless.service.provider.environment, environment);
+}
+
+module.exports = setEnvVariables;


### PR DESCRIPTION
Fixes #1 

Added a hook for invoke local. Set the resolved environment on service for local invocation.

Fixed race condition with pluginManager.run(). Invocations of other lifecycles must be awaited with "return" to ensure a reproducible lifecycle chain.

Tested with `serverless invoke local -p event.json -f my-function`