### PR TITLE
Fix issue with multiple environment variables for function

### DIFF
--- a/src/lib/setEnvVariables.js
+++ b/src/lib/setEnvVariables.js
@@ -18,6 +18,7 @@ function setEnvVariables(serverless, environment) {
 		if (funcEnv) {
 			_.assign(funcEnv, _.reduce(funcEnv, (acc, value, key) => {
 				acc[key] = environment[key];
+				return acc;
 			}, {}));
 		}
 	});


### PR DESCRIPTION
Crashed with `Cannot set property 'ENVIRONMENT_VARIABLE_NAME' of undefined`, because you weren't returning from inside the reduce when setting the environment variables, so if you have more than one environment variable for a function, the accumulator would be undefined on the second iteration.