### PR TITLE
stack resoruces output as env vars 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class ExportEnv {
 			_.assign(envVars, globalEnvironment);
 
 			// collect Resources Outputs
-			const resourcesOutputs = collecResourcesOutputs(this.serverless);
+			const resourcesOutputs = collectResourcesOutputs(this.serverless);
 			_.assign(envVars, resourcesOutputs);
 
 			// collect environment variables of functions

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const collectFunctionEnvVariables = require("./lib/collectFunctionEnvVariables")
 const setEnvVariables = require("./lib/setEnvVariables");
 const collectOfflineEnvVariables = require("./lib/collectOfflineEnvVariables");
 const resolveCloudFormationEnvVariables = require("./lib/resolveCloudFormationEnvVariables");
-const collectResourcesOutputs = require("./lib/collectResourcesOutputs");
+const collecResourcesOutputs = require("./lib/collecResourcesOutputs");
 const transformEnvVarsToString = require("./lib/transformEnvVarsToString");
 
 /**
@@ -65,7 +65,7 @@ class ExportEnv {
 			_.assign(envVars, globalEnvironment);
 
 			// collect Resources Outputs
-			const resourcesOutputs = collectResourcesOutputs(this.serverless);
+			const resourcesOutputs = collecResourcesOutputs(this.serverless);
 			_.assign(envVars, resourcesOutputs);
 
 			// collect environment variables of functions

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const collectFunctionEnvVariables = require("./lib/collectFunctionEnvVariables")
 const setEnvVariables = require("./lib/setEnvVariables");
 const collectOfflineEnvVariables = require("./lib/collectOfflineEnvVariables");
 const resolveCloudFormationEnvVariables = require("./lib/resolveCloudFormationEnvVariables");
+const collectResourcesOutputs = require("./lib/collectResourcesOutputs");
 const transformEnvVarsToString = require("./lib/transformEnvVarsToString");
 
 /**
@@ -62,6 +63,10 @@ class ExportEnv {
 			// collect global environment variables
 			const globalEnvironment = this.serverless.service.provider.environment;
 			_.assign(envVars, globalEnvironment);
+
+			// collect Resources Outputs
+			const resourcesOutputs = collectResourcesOutputs(this.serverless);
+			_.assign(envVars, resourcesOutputs);
 
 			// collect environment variables of functions
 			const functionEnvironment = collectFunctionEnvVariables(this.serverless);

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,8 @@ const collectFunctionEnvVariables = require("./lib/collectFunctionEnvVariables")
 const setEnvVariables = require("./lib/setEnvVariables");
 const collectOfflineEnvVariables = require("./lib/collectOfflineEnvVariables");
 const resolveCloudFormationEnvVariables = require("./lib/resolveCloudFormationEnvVariables");
-const collecResourcesOutputs = require("./lib/collecResourcesOutputs");
 const transformEnvVarsToString = require("./lib/transformEnvVarsToString");
-
+const collectResourcesOutputs = require("./lib/collectResourcesOutputs");
 /**
  * Serverless Plugin to extract Serverless' Lambda environment variables into
  * a local .env file for integration testing.

--- a/src/lib/collectResorucesOutputs.js
+++ b/src/lib/collectResorucesOutputs.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const _ = require("lodash");
+
+/**
+ * Collects Serverless Outputs resources
+ *
+ * @param {Serverless} serverless - Serverless Instance
+ * @returns {String[]} Returns a list of environment variables
+ */
+function collectResorucesOutputs(serverless) {
+
+	const outputs = _.get(serverless, "service.resources.Outputs", []);	
+	const envVars = {};
+
+	_.each(_.keys(outputs), key => {
+		 const value = outputs[key].Value;
+		 let envVarKey  = _.toUpper(_.snakeCase(key));
+		 let envVar ={[envVarKey] : value};
+	 	_.assign(envVars, envVar);
+	});
+
+	return envVars;
+}
+
+module.exports = collectResorucesOutputs;

--- a/src/lib/collectResourcesOutputs.js
+++ b/src/lib/collectResourcesOutputs.js
@@ -8,7 +8,7 @@ const _ = require("lodash");
  * @param {Serverless} serverless - Serverless Instance
  * @returns {String[]} Returns a list of environment variables
  */
-function collectResorucesOutputs(serverless) {
+function collectResourcesOutputs(serverless) {
 
 	const outputs = _.get(serverless, "service.resources.Outputs", []);	
 	const envVars = {};
@@ -23,4 +23,4 @@ function collectResorucesOutputs(serverless) {
 	return envVars;
 }
 
-module.exports = collectResorucesOutputs;
+module.exports = collectResourcesOutputs;


### PR DESCRIPTION
 stack resources output as env vars

In case you have this section in your `serverless.yml`:
``` resources:
     Resources:
  NewResource:
      Type: AWS::S3::Bucket
      Properties:
        BucketName: my-new-bucket
  Outputs:
     NewOutput:
       Description: "Description for the output"
       Value: "Some output value"
```

this PR will export the `Outputs` as env vars. in this example will add 
```NEW_OUTPUT: "Some output value"```