### PR TITLE
Fix error when serverless.yml doesn't contain a custom section

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ class ExportEnv {
     return BbPromise.try(() => {
       process.env.SLS_DEBUG && this.serverless.cli.log("Writing .env file");
 
-      const params = this.serverless.service.custom["export-env"];
+      const params = _.get(this.serverless, 'service.custom.export-env');
 
       let filename = this.envFileName;
       let pathFromRoot = "";


### PR DESCRIPTION
When serverless.yml didn't contain a custom section, the following
error was being being thrown:

`Cannot read property 'export-env' of undefined`