### PR TITLE
feat: set resource values from stack output

### DIFF
--- a/src/lib/collectResourcesOutputs.js
+++ b/src/lib/collectResourcesOutputs.js
@@ -6,14 +6,19 @@ const _ = require("lodash");
  * Collects Serverless Outputs resources
  *
  * @param {Serverless} serverless - Serverless Instance
+ * @param {Array[Map]} stackOutputs - an array of stack outputs
  * @returns {String[]} Returns a list of environment variables
  */
-function collectResourcesOutputs(serverless) {
+function collectResourcesOutputs(serverless, stackOutputs = {}) {
   const outputs = _.get(serverless, "service.resources.Outputs", []);
   const envVars = {};
 
   _.each(_.keys(outputs), (key) => {
-    const value = outputs[key].Value;
+    const outputValue = _.find(stackOutputs, ["OutputKey", key]);
+    const value =
+      outputValue !== undefined && outputValue["OutputValue"] !== undefined
+        ? outputValue["OutputValue"]
+        : outputs[key].Value;
     const envVarKey = _.toUpper(_.snakeCase(key));
     const envVar = { [envVarKey]: value };
     _.assign(envVars, envVar);

--- a/src/lib/collectStackOutputs.js
+++ b/src/lib/collectStackOutputs.js
@@ -1,0 +1,31 @@
+"use strict";
+
+function describeStack(AWS, outputs, nextToken) {
+  outputs = outputs || [];
+  return AWS.request("CloudFormation", "describeStacks", {
+    StackName: AWS.naming.getStackName(),
+    NextToken: nextToken,
+  })
+    .then((response) => {
+      outputs.push.apply(outputs, response.Stacks[0].Outputs);
+      if (response.NextToken) {
+        // Query next page
+        return describeStack(AWS, outputs, response.NextToken);
+      }
+    })
+    .return(outputs);
+}
+
+/**
+ * Collects CloudFormation stack outputs
+ *
+ * @param {Serverless} serverless - Serverless Instance
+ * @returns {Promise<Array[Map]>} Resolves with the list of outputs
+ */
+function collectStackOutputs(serverless) {
+  const AWS = serverless.providers.aws;
+
+  return describeStack(AWS);
+}
+
+module.exports = collectStackOutputs;


### PR DESCRIPTION
This is a proposal for a fix for the following use case as mentioned in https://github.com/arabold/serverless-export-env/issues/21 .

Let's say we have something like this in the `Resource` section of a `serverless.yml`:
```
resources:
  Resources:
   SNSSomethingNotificationTopic:
      Type: AWS::SNS::Topic

  Outputs:
    SNSSomethingNotificationTopicName:
      Value: !GetAtt SNSSomethingNotificationTopic.TopicName
```
Then the `SNSSomethingNotificationTopicName` would not get resolved to the actual value but instead a JSON object containing something this after the call to `collectResourceOutputs`:
``` 
{ 'Fn::GetAtt': [ 'SNSSomethingNotificationTopic', 'TopicName' ] }
```
Which when it gets written to the `.env` file becomes `SNS_NOTIFICATION_TOPIC_NAME: [object Object]`

It would seem that the computed value is not fetched when the stack is created or updated for this kind of use case so in short my proposal is to try and get the actual stacks output values from AWS and map them to the outputs before using any other values.
