### PR TITLE
feat: Remove dependency on Bluebird API for promises from Framework

### DIFF
--- a/src/lib/collectStackOutputs.js
+++ b/src/lib/collectStackOutputs.js
@@ -13,7 +13,7 @@ function describeStack(AWS, outputs, nextToken) {
         return describeStack(AWS, outputs, response.NextToken);
       }
     })
-    .return(outputs);
+    .then(() => outputs);
 }
 
 /**

--- a/src/lib/resolveCloudFormationEnvVariables.js
+++ b/src/lib/resolveCloudFormationEnvVariables.js
@@ -6,14 +6,14 @@ const BbPromise = require("bluebird"),
 function listExports(AWS, exports, nextToken) {
   exports = exports || [];
   return AWS.request("CloudFormation", "listExports", { NextToken: nextToken })
-    .tap((response) => {
+    .then((response) => {
       exports.push.apply(exports, response.Exports);
       if (response.NextToken) {
         // Query next page
         return listExports(AWS, exports, response.NextToken);
       }
     })
-    .return(exports);
+    .then(() => exports);
 }
 
 function listStackResources(AWS, resources, nextToken) {
@@ -29,7 +29,7 @@ function listStackResources(AWS, resources, nextToken) {
         return listStackResources(AWS, resources, response.NextToken);
       }
     })
-    .return(resources);
+    .then(() => resources);
 }
 
 /**


### PR DESCRIPTION
Due to an ongoing effort to remove `Bluebird` and use native `async/await` internally in Serverless Framework, some of the functionalities depending on Bluebird API might stop working for users with Framework in version `2.x`. This PRs aims to migrate from Bluebird API to native Promises. I've tested the functionality locally, but please let me know if you see any issues with the proposed changes. Thanks :bow: 

Closes: #27 and #26 