### PR TITLE
Add "serverless" to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.1.2"
   },
+  "peerDependencies": {
+    "serverless": "1.x || 2.x"
+  },
   "prettier": {
     "printWidth": 120,
     "tabWidth": 2,


### PR DESCRIPTION
In order to provide more "official" support for potential new major versions of the Serverless Framework, it would be good to define `peerDependencies`, which can later be officially updated to ensure that plugin works with newer versions of the Framework as intended. Please let me know what do you think :bow: 