### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier": "^2.1.2"
   },
   "peerDependencies": {
-    "serverless": "1.x || 2.x"
+    "serverless": "1 || 2 || 3"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good to whitelist v3 of the Framework in peer dependencies section