### PR TITLE
fix: Cannot convert undefined or null to object

### DIFF
--- a/src/lib/resolveCloudFormationEnvVariables.js
+++ b/src/lib/resolveCloudFormationEnvVariables.js
@@ -48,7 +48,7 @@ function resolveGetAtt(refs, resource) {
 
 function resolveResources(AWS, stack, resources, exports, toBeResolved, maps) {
   return BbPromise.all([AWS.getRegion(), AWS.getAccountId()]).spread((region, accountId) => {
-    const node = _.assign({}, { toBeResolved });
+    const node = _.assign({}, { toBeResolved, Parameters: [] });
     const refResolvers = _.merge(
       {
         "AWS::Partition": "aws", // FIXME How to determine correct value?


### PR DESCRIPTION
`NodeEvaluator` (https://github.com/robessog/cfn-resolver-lib/blob/9269810976848444e3c8dd85c43997e8f34538f5/src/nodeEvaluator.js#L17) expects a list of parameters but the provided `node` parameter does not contain this attribute thus subsequent usage fails.

fixes #46